### PR TITLE
Updated respec-version in index.html

### DIFF
--- a/connegp/index.html
+++ b/connegp/index.html
@@ -2670,6 +2670,6 @@ ex:connegDataAccessService
     </section>
   </section>
   <script class="remove" src="config.js"></script>
-  <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
+  <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
 </body>
 </html>


### PR DESCRIPTION
respec issued a warning: 
"respec-w3c-common" profile has been deprecated in favor of the "respec-w3c" profile and will not receive any future updates, including the support for W3C 2020 process. Please migrate to "respec-w3c" profile."
This commit replaces the reference in the document