### PR TITLE
add github action for Echidna, update respecConfig

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,29 @@
+# Example: Override respecConfig for W3C deployment and validators.
+name: Echidna Auto-publish
+on:
+  pull_request:
+    paths: ["connegp/**"]
+  push:
+    branches: [gh-pages]
+    paths: ["connegp/**"]
+jobs:
+  main:
+    name: Echidna Auto-publish WD
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: respec
+          SOURCE: connegp/index.html
+          VALIDATE_LINKS: false
+          VALIDATE_MARKUP: true
+          ACTIONS_STEP_DEBUG: true
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: https://www.w3.org/2023/08/23-dxwg-minutes.html#r02
+          W3C_BUILD_OVERRIDE: |
+            specStatus: WD
+            shortName: dx-prof-conneg
+

--- a/connegp/config.js
+++ b/connegp/config.js
@@ -18,7 +18,8 @@ var respecConfig = {
         name:       "Rob Atkinson",
         company:    "Metalinkage, Open Geospatial Consortium",
         companyURL: "http://www.ogc.org",
-        orcid:      "0000-0002-7878-2693"
+        orcid:      "0000-0002-7878-2693",
+        w3cid:      90763
       },
       {
         name:       "Nicholas J. Car",

--- a/connegp/config.js
+++ b/connegp/config.js
@@ -1,9 +1,10 @@
 var respecConfig = {
-    specStatus: "WD",
-    shortName: "dx-connegp",
+    group: "dx",
+    specStatus: "ED",
+    shortName: "dx-prof-conneg",
     edDraftURI: "https://w3c.github.io/dx-connegp/connegp/",
     previousPublishDate: "2019-04-30",
-    previousMaturity: "PWD",
+    previousMaturity: "WD",
     testSuiteURI: "https://github.com/w3c/prof-conneg-testing",
     implementationReportURI: "https://w3c.github.io/dx-connegp/connegp-implementation-report/",
     canonicalURI: "TR",
@@ -34,10 +35,7 @@ var respecConfig = {
             href:  "https://ruben.verborgh.org/"
     	}]
     }],
-    wg: "Dataset Exchange Working Group",
-    wgURI: "https://www.w3.org/2017/dxwg/",
     wgPublicList: "public-dxwg-comments",
-    wgPatentURI: "https://www.w3.org/2004/01/pp-impl/99375/status",
     inlineCSS: "true",
     lint: "false",
     maxTocLevel: 3,


### PR DESCRIPTION
NB: I removed a few deprecated respecConfig keys (wg, wgURI, wgPatentURI)

Per my action https://www.w3.org/2023/08/23-dxwg-minutes.html#a03